### PR TITLE
Update configmap-module-keycloak.yaml

### DIFF
--- a/workshop-deployer/templates/configmap-module-keycloak.yaml
+++ b/workshop-deployer/templates/configmap-module-keycloak.yaml
@@ -35,5 +35,24 @@ data:
             "values": "\ntargetNamespaces: globex-keycloak-{{ .Values.variable.user }}\n"
           }
         }
-      }
+      },
+      "clusterResourceWhitelist": [
+        {
+          "apiGroups": [""],
+          "kind": "Namespace",
+          "name": "{{ .Values.module.module_keycloak.namespace }}"
+        }
+      ],
+      "clusterRoleBindings": [
+        {
+          "name": "argocd-cluster-admin-binding",
+          "subjects": [
+            {
+              "kind": "ServiceAccount",
+              "name": "globex-gitops-user1-argocd-application-controller",
+              "namespace": "{{ .Values.module.module_keycloak.namespace }}"
+            }
+          ]
+        }
+      ]
     }


### PR DESCRIPTION
Added ClusterRoleBinding to Argo CD Application manifest, enabling deployment of Keycloak components with required permissions.